### PR TITLE
ci: update workflow w/ PR-preview & main deployment

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,103 @@
+# GitHub Actions Workflows
+
+## TL;DR
+
+**To update openqse.org:**
+1. Make changes in a branch
+2. Push to GitHub
+3. Merge to `main`
+4. ✅ Auto-deploys to openqse.org
+
+**PR Previews:**
+- Open a PR → Get preview at `https://openqse.org/previews/pr-123/`
+- Review changes live before merging
+- Preview auto-cleans up when PR is closed
+
+---
+
+## How It Works
+
+### Main Deployment
+- `main` branch → Deploys to `gh-pages` branch root → `openqse.org`
+- Workflow: `.github/workflows/jekyll.yml`
+
+### PR Previews
+- PR branches → Deploy to `gh-pages/previews/pr-X/` subdirectories → `https://openqse.org/previews/pr-X/`
+- Workflow: `.github/workflows/pr-preview.yml`
+- Bot comments on PR with preview URL
+- Auto-updates on new commits
+- Auto-cleans up when PR closes
+- **Note:** Previews are accessible via the custom domain once main site is deployed
+
+---
+
+## One-Time Setup Required
+
+### 1. Create the gh-pages branch
+
+```bash
+git checkout --orphan gh-pages
+git rm -rf .
+echo "# PR Previews" > README.md
+git add README.md
+git commit -m "Initialize gh-pages for PR previews"
+git push origin gh-pages
+git checkout main
+```
+
+### 2. Configure GitHub Pages
+
+In repository **Settings** → **Pages**:
+- **Build and deployment**:
+  - **Source:** Deploy from a branch
+  - **Branch:** `gh-pages` / `(root)`
+- Click **Save**
+
+**Full path:** Settings → Pages → Build and deployment → Source → Deploy from a branch
+
+### 3. Enable Workflow Permissions
+
+In repository **Settings** → **Actions** → **General**:
+- Under "Workflow permissions":
+  - ✅ Select **Read and write permissions**
+  - ✅ Check **Allow GitHub Actions to create and approve pull requests**
+- Click **Save**
+
+---
+
+## Usage
+
+### Creating a PR
+1. Create a branch and push your changes
+2. Open a pull request
+3. The workflow automatically builds your site and deploys to `https://openqse.org/previews/pr-{number}/`
+4. A bot comment appears on your PR with the preview URL
+
+### Updating a PR
+- Push new commits to your PR branch
+- The preview automatically rebuilds and updates
+- The bot comment updates with the new commit hash
+
+### Merging to Production
+1. Review your changes at the PR preview URL
+2. Merge the PR to `main`
+3. The main workflow deploys to production at `https://openqse.org`
+4. The PR preview is automatically cleaned up
+
+---
+
+## Troubleshooting
+
+**Preview URL returns 404:**
+- Wait 2-3 minutes after the workflow completes for GitHub Pages to update
+- Verify the workflow succeeded in the Actions tab
+- Check that `gh-pages` branch exists
+
+**Workflow fails:**
+- Check Settings → Actions → General → Workflow permissions
+- Ensure "Read and write permissions" is enabled
+
+**openqse.org doesn't work after setup:**
+- Verify the CNAME file contains `openqse.org`
+- Check Settings → Pages shows "Custom domain: openqse.org"
+- DNS settings should already be correct (no changes needed)

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,9 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+# Deploy main branch to production (openqse.org)
 name: Deploy Jekyll site to Pages
 
 on:
@@ -16,9 +11,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -27,39 +20,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
-  build:
+  # Build and deploy job
+  build-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
+          ruby-version: '3.1'
+          bundler-cache: true
+          cache-version: 0
+
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --baseurl ""
         env:
           JEKYLL_ENV: production
-      - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          cname: openqse.org
+          keep_files: true  # Keep PR preview directories

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,113 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Build and deploy preview
+  build-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "/previews/pr-${{ github.event.pull_request.number }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy preview to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          destination_dir: previews/pr-${{ github.event.pull_request.number }}
+          keep_files: true
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://openqse.org/previews/pr-${prNumber}/`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Preview deployed')
+            );
+
+            const commentBody = `## 🚀 Preview deployed!
+
+            **Preview URL:** ${previewUrl}
+
+            Built from commit: ${context.payload.pull_request.head.sha.substring(0, 7)}
+
+            The preview will update automatically when you push new commits to this PR.`;
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+            }
+
+  # Clean up preview when PR is closed
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -d "previews/pr-${{ github.event.pull_request.number }}" ]; then
+            git rm -rf "previews/pr-${{ github.event.pull_request.number }}"
+            git commit -m "Clean up preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          fi
+
+      - name: Comment cleanup
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: '🧹 Preview cleaned up.'
+            });


### PR DESCRIPTION
Changes:
- Updated jekyll.yml to deploy main branch to production (openqse.org)
  - Switched to peaceiris/actions-gh-pages for deployment
  - Simplified to single build-deploy job
  - Configured to keep PR preview directories
- Added pr-preview.yml workflow for pull request previews
  - Builds and deploys PRs to pr-<number> subdirectories
  - Automatic cleanup on PR close
  - Posts preview URL as PR comment
- Added .github/README.md documenting CI setup and workflows
- Thanks Claude!